### PR TITLE
Missing a division during tile creation on x and y

### DIFF
--- a/app/src/main/scala/Controller/GameController.scala
+++ b/app/src/main/scala/Controller/GameController.scala
@@ -33,7 +33,7 @@ class GameController(playerName: String, mapDifficulty: Int) extends LogHelper {
   var selected_cell: Option[Tower] = None
   var wave_counter = 0
   var release_selected_cell_and_tower: Boolean = false
-  val framerate = 1.0 / 30.0 * 1000
+  val frameRate: Double = 1.0 / 30.0 * 1000
   val wave = new WaveImpl(1, this)
   var lastTime = 0L
 
@@ -43,9 +43,15 @@ class GameController(playerName: String, mapDifficulty: Int) extends LogHelper {
    */
   def onCellClicked(x: Double, y: Double): Unit = {
     if (isTowerSelected &&
-      isTileBuildable(x.toInt, y.toInt)
+      isTileBuildable((x/64).toInt, (y/64).toInt)
       && playerHaveEnoughMoneyEnough) {
-      val tower = selected_tower.get.clone(x, y)
+
+      // x and y preparation, TODO: refactor @Hama
+      val xPos: Int = (x/64).toInt * 64
+      val yPos: Int = (y/64).toInt * 64
+      // TODO end
+
+      val tower = selected_tower.get.clone(xPos, yPos)
       this += tower
       selected_tower = Option(tower)
     } else if (isTowerSelected && !playerHaveEnoughMoneyEnough) {

--- a/app/src/test/scala/Tower/TowerGenerationTest.scala
+++ b/app/src/test/scala/Tower/TowerGenerationTest.scala
@@ -29,4 +29,14 @@ class TowerGenerationTest extends AnyFunSuite {
     assert(tower.name().equals(CannonTower.name))
     assert(tower.player.playerName.equals(controller.player.playerName))
   }
+
+  test("Tower positioning"){
+    val x: Int = (31.6/64).toInt
+    val y: Int = (51.31/64).toInt
+    println(x + " - " + y)
+
+    val x2: Int = (154.64/64).toInt
+    val y2: Int = (51.14/64).toInt
+    println(x2 + " - " + y2)
+  }
 }


### PR DESCRIPTION
Fixed bug of array index out of bound, it was generated because x and y wasn't divided by 64 during tower creation

The position is calculated starting from x and y, it is Double values
1. we divide it by 64 (standard dimension of tile)
2. convert to int the result (now we got the position of the tile in the grid)
3. multiply for 64 the result because we want the position where the tower should be draw